### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ wheels/
 
 # Files and folder contents
 *.txt
-VectorDB/vectorstore/
-scraped_files/
+# VectorDB/vectorstore/
+# scraped_files/


### PR DESCRIPTION
Updated .gitignore to make VectorDB/vectorstore and scraped_files visible

#3 